### PR TITLE
Add more themes to the front-end

### DIFF
--- a/Store/src/App.tsx
+++ b/Store/src/App.tsx
@@ -22,17 +22,18 @@ import { StoreDataProvider } from "./StoreDataProvider";
 import axios from "axios";
 import Installments from "./pages/Installments/Installments";
 import Employee from "./pages/Employee/Employee";
+import Themes from "./pages/Setting/Components/Themes";
 
 axios.defaults.withCredentials = true;
 
-const localMode = localStorage.getItem("mode");
-let mode: "dark" | "light";
+const localMode = localStorage.getItem("theme");
+let mode: keyof typeof themes;
 
-if (!localMode || (localMode !== "dark" && localMode !== "light")) {
-  localStorage.setItem("mode", "dark");
-  mode = "dark";
+if (!localMode || !themes[localMode]) {
+  localStorage.setItem("theme", "light");
+  mode = "light";
 } else {
-  mode = localMode;
+  mode = localMode as keyof typeof themes;
 }
 
 const queryClient = new QueryClient({
@@ -44,35 +45,8 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
-  const [themeMode, setThemeMode] = useState<"dark" | "light">(mode);
-  const theme = createTheme({
-    direction: "rtl",
-    palette: {
-      mode: themeMode,
-      background: {
-        default: themeMode === "dark" ? "#323f54" : "#d5e5ff",
-        paper: themeMode === "dark" ? "#293649" : "#c1d9ff",
-      },
-      divider: themeMode === "dark" ? "#3d4d64" : "#94b6ff",
-    },
-    components: {
-      MuiCssBaseline: {
-        styleOverrides: {
-          body: {
-            backgroundImage:
-              themeMode === "dark"
-                ? "radial-gradient(circle at center, #3d4d64 0%, #263245 100%);"
-                : "radial-gradient(circle at center, #8cb2ed 0%, #aabbff 7  0%);",
-            backgroundAttachment: "fixed",
-            backgroundSize: "cover",
-            backgroundRepeat: "no-repeat",
-            backgroundPosition: "center",
-            minHeight: "100vh",
-          },
-        },
-      },
-    },
-  });
+  const [themeMode, setThemeMode] = useState<keyof typeof themes>(mode);
+  const theme = themes[themeMode];
 
   return (
     <Rtl>

--- a/Store/src/Layout.tsx
+++ b/Store/src/Layout.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Button, Toolbar, Grid, IconButton } from "@mui/material";
+import { AppBar, Button, Toolbar, Grid } from "@mui/material";
 import { Profile, ViewContainer } from "./pages/Shared/Utils";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
@@ -9,8 +9,6 @@ import {
   useEffect,
 } from "react";
 import { NavLink } from "react-router-dom";
-import DarkModeIcon from "@mui/icons-material/DarkMode";
-import BrightnessHighIcon from "@mui/icons-material/BrightnessHigh";
 import { StoreContext } from "./StoreDataProvider";
 import axios from "axios";
 import { useMutation } from "@tanstack/react-query";
@@ -100,21 +98,6 @@ const Layout = ({
               <Button variant="contained" onClick={() => switchAccount()}>
                 تبديل المستخدم
               </Button>
-              <IconButton
-                onClick={() => {
-                  setThemeMode((prev) => (prev === "dark" ? "light" : "dark"));
-                  localStorage.setItem(
-                    "mode",
-                    themeMode === "dark" ? "light" : "dark"
-                  );
-                }}
-              >
-                {themeMode === "dark" ? (
-                  <BrightnessHighIcon />
-                ) : (
-                  <DarkModeIcon />
-                )}
-              </IconButton>
             </Grid>
           </Grid>
         </Toolbar>

--- a/Store/src/pages/Setting/Components/Themes.tsx
+++ b/Store/src/pages/Setting/Components/Themes.tsx
@@ -1,1 +1,201 @@
-// to be implemented
+import React, { useState, useEffect } from 'react';
+import { Grid, Card, Typography, Button } from '@mui/material';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const themes = {
+  light: createTheme({
+    palette: {
+      mode: 'light',
+      background: {
+        default: '#d5e5ff',
+        paper: '#c1d9ff',
+      },
+      divider: '#94b6ff',
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundImage: 'radial-gradient(circle at center, #8cb2ed 0%, #aabbff 70%);',
+            backgroundAttachment: 'fixed',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            minHeight: '100vh',
+          },
+        },
+      },
+    },
+  }),
+  dark: createTheme({
+    palette: {
+      mode: 'dark',
+      background: {
+        default: '#323f54',
+        paper: '#293649',
+      },
+      divider: '#3d4d64',
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundImage: 'radial-gradient(circle at center, #3d4d64 0%, #263245 100%);',
+            backgroundAttachment: 'fixed',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            minHeight: '100vh',
+          },
+        },
+      },
+    },
+  }),
+  theme1: createTheme({
+    palette: {
+      mode: 'light',
+      primary: {
+        main: '#ff5722',
+      },
+      background: {
+        default: '#ffe0b2',
+        paper: '#ffcc80',
+      },
+      divider: '#ffab40',
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundImage: 'radial-gradient(circle at center, #ffab40 0%, #ffcc80 70%);',
+            backgroundAttachment: 'fixed',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            minHeight: '100vh',
+          },
+        },
+      },
+    },
+  }),
+  theme2: createTheme({
+    palette: {
+      mode: 'dark',
+      primary: {
+        main: '#4caf50',
+      },
+      background: {
+        default: '#2e7d32',
+        paper: '#388e3c',
+      },
+      divider: '#66bb6a',
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundImage: 'radial-gradient(circle at center, #66bb6a 0%, #388e3c 100%);',
+            backgroundAttachment: 'fixed',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            minHeight: '100vh',
+          },
+        },
+      },
+    },
+  }),
+  theme3: createTheme({
+    palette: {
+      mode: 'light',
+      primary: {
+        main: '#2196f3',
+      },
+      background: {
+        default: '#bbdefb',
+        paper: '#90caf9',
+      },
+      divider: '#64b5f6',
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundImage: 'radial-gradient(circle at center, #64b5f6 0%, #90caf9 70%);',
+            backgroundAttachment: 'fixed',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            minHeight: '100vh',
+          },
+        },
+      },
+    },
+  }),
+  theme4: createTheme({
+    palette: {
+      mode: 'dark',
+      primary: {
+        main: '#9c27b0',
+      },
+      background: {
+        default: '#6a1b9a',
+        paper: '#7b1fa2',
+      },
+      divider: '#ba68c8',
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundImage: 'radial-gradient(circle at center, #ba68c8 0%, #7b1fa2 100%);',
+            backgroundAttachment: 'fixed',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            minHeight: '100vh',
+          },
+        },
+      },
+    },
+  }),
+};
+
+const Themes = () => {
+  const [selectedTheme, setSelectedTheme] = useState(localStorage.getItem('theme') || 'light');
+
+  useEffect(() => {
+    localStorage.setItem('theme', selectedTheme);
+  }, [selectedTheme]);
+
+  return (
+    <ThemeProvider theme={themes[selectedTheme]}>
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <Typography variant="h4">اختر السمة</Typography>
+        </Grid>
+        {Object.keys(themes).map((themeKey) => (
+          <Grid item xs={4} key={themeKey}>
+            <Card
+              onClick={() => setSelectedTheme(themeKey)}
+              sx={{
+                cursor: 'pointer',
+                padding: 2,
+                textAlign: 'center',
+                backgroundColor: themes[themeKey].palette.background.default,
+                color: themes[themeKey].palette.text.primary,
+              }}
+            >
+              <Typography variant="h6">{themeKey}</Typography>
+              <Button variant="contained" color="primary">
+                اختر
+              </Button>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </ThemeProvider>
+  );
+};
+
+export default Themes;


### PR DESCRIPTION
Add new themes and theme selection functionality to the settings page.

* **Themes.tsx**
  - Add a new section for theme selection in the settings page.
  - Define 6 themes including the current 2 (light and dark).
  - Add a preview for each theme in a small card.
  - Save the selected theme in localStorage and use it.

* **App.tsx**
  - Import the new themes from `Themes.tsx`.
  - Update the theme provider to use the selected theme from localStorage.
  - Remove the light vs dark theme toggle from the layout.

* **Layout.tsx**
  - Remove the light vs dark theme toggle button.
  - Update the layout to use the selected theme from localStorage.

