### PR TITLE
Add themes to settings page

### DIFF
--- a/Store/src/App.tsx
+++ b/Store/src/App.tsx
@@ -14,7 +14,6 @@ import Products from "./pages/Products/Productds";
 import Bills from "./pages/Bills/Bills";
 import Cash from "./pages/Cash/Cash";
 import Settings from "./pages/Setting/Setting";
-import { useState } from "react";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import Login from "./pages/Login/Login";
 import Analytics from "./pages/Analytics/Analytics";
@@ -22,23 +21,13 @@ import { StoreDataProvider } from "./StoreDataProvider";
 import axios from "axios";
 import Installments from "./pages/Installments/Installments";
 import Employee from "./pages/Employee/Employee";
+import { Theme, themes } from "./themes";
 
 axios.defaults.withCredentials = true;
 
-const localTheme = localStorage.getItem("selectedTheme");
-let themeSettings;
-
-if (!localTheme) {
-  themeSettings = {
-    mode: "dark",
-    primary: "#1976d2",
-    secondary: "#ff4081",
-    background: "#e3f2fd",
-  };
-  localStorage.setItem("selectedTheme", JSON.stringify(themeSettings));
-} else {
-  themeSettings = JSON.parse(localTheme);
-}
+const localTheme = localStorage.getItem("themeName");
+let themeSettings: Theme =
+  themes.find((t) => t.name === localTheme) || themes[0];
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -48,37 +37,73 @@ const queryClient = new QueryClient({
   },
 });
 
+console.log("themeSettings", localTheme);
+
 const App = () => {
-  const [themeMode, setThemeMode] = useState(themeSettings.mode);
   const theme = createTheme({
     direction: "rtl",
     palette: {
-      mode: themeMode,
+      mode: themeSettings.mode,
       primary: {
         main: themeSettings.primary,
+        contrastText: themeSettings.mode === "light" ? "#ffffff" : "#000000",
       },
       secondary: {
         main: themeSettings.secondary,
+        contrastText: themeSettings.mode === "light" ? "#ffffff" : "#000000",
       },
       background: {
         default: themeSettings.background,
-        paper: themeMode === "dark" ? "#293649" : "#c1d9ff",
+        paper: themeSettings.paper,
       },
-      divider: themeMode === "dark" ? "#3d4d64" : "#94b6ff",
+      text: themeSettings.text,
+      divider: themeSettings.divider,
+      error: {
+        main: themeSettings.error,
+      },
+      warning: {
+        main: themeSettings.warning,
+      },
+      info: {
+        main: themeSettings.info,
+      },
+      success: {
+        main: themeSettings.success,
+      },
+      action: themeSettings.action,
     },
     components: {
       MuiCssBaseline: {
         styleOverrides: {
           body: {
-            backgroundImage:
-              themeMode === "dark"
-                ? "radial-gradient(circle at center, #3d4d64 0%, #263245 100%);"
-                : "radial-gradient(circle at center, #8cb2ed 0%, #aabbff 7  0%);",
+            backgroundImage: themeSettings.backgroundImage,
             backgroundAttachment: "fixed",
             backgroundSize: "cover",
             backgroundRepeat: "no-repeat",
             backgroundPosition: "center",
             minHeight: "100vh",
+          },
+        },
+      },
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            backgroundColor: themeSettings.surface.main,
+            borderColor: themeSettings.surface.border,
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            textTransform: "none",
+          },
+        },
+      },
+      MuiDivider: {
+        styleOverrides: {
+          root: {
+            borderColor: themeSettings.divider,
           },
         },
       },
@@ -92,7 +117,7 @@ const App = () => {
           <StoreDataProvider>
             <ThemeProvider theme={theme}>
               <CssBaseline />
-              <Layout themeMode={themeMode} setThemeMode={setThemeMode}>
+              <Layout>
                 <Routes>
                   <Route path="/sell" element={<Sell />} />
                   <Route path="/add-to-storage" element={<Storage />} />

--- a/Store/src/App.tsx
+++ b/Store/src/App.tsx
@@ -25,14 +25,19 @@ import Employee from "./pages/Employee/Employee";
 
 axios.defaults.withCredentials = true;
 
-const localMode = localStorage.getItem("mode");
-let mode: "dark" | "light";
+const localTheme = localStorage.getItem("selectedTheme");
+let themeSettings;
 
-if (!localMode || (localMode !== "dark" && localMode !== "light")) {
-  localStorage.setItem("mode", "dark");
-  mode = "dark";
+if (!localTheme) {
+  themeSettings = {
+    mode: "dark",
+    primary: "#1976d2",
+    secondary: "#ff4081",
+    background: "#e3f2fd",
+  };
+  localStorage.setItem("selectedTheme", JSON.stringify(themeSettings));
 } else {
-  mode = localMode;
+  themeSettings = JSON.parse(localTheme);
 }
 
 const queryClient = new QueryClient({
@@ -44,13 +49,19 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
-  const [themeMode, setThemeMode] = useState<"dark" | "light">(mode);
+  const [themeMode, setThemeMode] = useState(themeSettings.mode);
   const theme = createTheme({
     direction: "rtl",
     palette: {
       mode: themeMode,
+      primary: {
+        main: themeSettings.primary,
+      },
+      secondary: {
+        main: themeSettings.secondary,
+      },
       background: {
-        default: themeMode === "dark" ? "#323f54" : "#d5e5ff",
+        default: themeSettings.background,
         paper: themeMode === "dark" ? "#293649" : "#c1d9ff",
       },
       divider: themeMode === "dark" ? "#3d4d64" : "#94b6ff",

--- a/Store/src/Layout.tsx
+++ b/Store/src/Layout.tsx
@@ -57,6 +57,14 @@ const Layout = ({
     },
   });
 
+  const handleThemeToggle = () => {
+    const newThemeMode = themeMode === "dark" ? "light" : "dark";
+    setThemeMode(newThemeMode);
+    const themeSettings = JSON.parse(localStorage.getItem("selectedTheme") || "{}");
+    themeSettings.mode = newThemeMode;
+    localStorage.setItem("selectedTheme", JSON.stringify(themeSettings));
+  };
+
   return (
     <>
       <AppBar
@@ -100,15 +108,7 @@ const Layout = ({
               <Button variant="contained" onClick={() => switchAccount()}>
                 تبديل المستخدم
               </Button>
-              <IconButton
-                onClick={() => {
-                  setThemeMode((prev) => (prev === "dark" ? "light" : "dark"));
-                  localStorage.setItem(
-                    "mode",
-                    themeMode === "dark" ? "light" : "dark"
-                  );
-                }}
-              >
+              <IconButton onClick={handleThemeToggle}>
                 {themeMode === "dark" ? (
                   <BrightnessHighIcon />
                 ) : (

--- a/Store/src/Layout.tsx
+++ b/Store/src/Layout.tsx
@@ -1,16 +1,8 @@
-import { AppBar, Button, Toolbar, Grid, IconButton } from "@mui/material";
+import { AppBar, Button, Toolbar, Grid } from "@mui/material";
 import { Profile, ViewContainer } from "./pages/Shared/Utils";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-  Dispatch,
-  ReactNode,
-  SetStateAction,
-  useContext,
-  useEffect,
-} from "react";
+import { ReactNode, useContext, useEffect } from "react";
 import { NavLink } from "react-router-dom";
-import DarkModeIcon from "@mui/icons-material/DarkMode";
-import BrightnessHighIcon from "@mui/icons-material/BrightnessHigh";
 import { StoreContext } from "./StoreDataProvider";
 import axios from "axios";
 import { useMutation } from "@tanstack/react-query";
@@ -21,15 +13,7 @@ const logoutWihtoutEndingShift = async () => {
   });
 };
 
-const Layout = ({
-  children,
-  themeMode,
-  setThemeMode,
-}: {
-  children: ReactNode;
-  themeMode: "dark" | "light";
-  setThemeMode: Dispatch<SetStateAction<"dark" | "light">>;
-}) => {
+const Layout = ({ children }: { children: ReactNode }) => {
   const location = useLocation();
   if (location.pathname === "/login") {
     return <>{children}</>;
@@ -40,7 +24,8 @@ const Layout = ({
 
   useEffect(() => {
     if (
-      profile && !profile.user.paths.some((path) => location.pathname.startsWith(path))
+      profile &&
+      !profile.user.paths.some((path) => location.pathname.startsWith(path))
     ) {
       navigate("/sell");
     }
@@ -56,14 +41,6 @@ const Layout = ({
       console.log(error);
     },
   });
-
-  const handleThemeToggle = () => {
-    const newThemeMode = themeMode === "dark" ? "light" : "dark";
-    setThemeMode(newThemeMode);
-    const themeSettings = JSON.parse(localStorage.getItem("selectedTheme") || "{}");
-    themeSettings.mode = newThemeMode;
-    localStorage.setItem("selectedTheme", JSON.stringify(themeSettings));
-  };
 
   return (
     <>
@@ -91,11 +68,12 @@ const Layout = ({
                 width: "fit-content",
               }}
             >
-              {profile && profile.user.pages.map((page, index) => (
-                <NavLink key={index} to={profile.user.paths[index]}>
-                  <Button>{page}</Button>
-                </NavLink>
-              ))}
+              {profile &&
+                profile.user.pages.map((page, index) => (
+                  <NavLink key={index} to={profile.user.paths[index]}>
+                    <Button>{page}</Button>
+                  </NavLink>
+                ))}
             </Grid>
             <Grid
               item
@@ -108,13 +86,6 @@ const Layout = ({
               <Button variant="contained" onClick={() => switchAccount()}>
                 تبديل المستخدم
               </Button>
-              <IconButton onClick={handleThemeToggle}>
-                {themeMode === "dark" ? (
-                  <BrightnessHighIcon />
-                ) : (
-                  <DarkModeIcon />
-                )}
-              </IconButton>
             </Grid>
           </Grid>
         </Toolbar>

--- a/Store/src/pages/Analytics/Components/AlertsAnalytics.tsx
+++ b/Store/src/pages/Analytics/Components/AlertsAnalytics.tsx
@@ -44,6 +44,7 @@ const AlertsAnalytics = () => {
                   sx={{
                     p: 2,
                     bgcolor: alert.urgent ? "error.main" : "background.paper",
+                    color: alert.urgent ? "white" : "text.primary",
                   }}
                 >
                   <Typography variant="h6">{alert.name}</Typography>

--- a/Store/src/pages/Analytics/Components/ProductsAnalytics.tsx
+++ b/Store/src/pages/Analytics/Components/ProductsAnalytics.tsx
@@ -10,6 +10,7 @@ import {
   Grid,
   TextField,
   Typography,
+  useTheme,
 } from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -50,6 +51,10 @@ const ProductsAnalytics = () => {
   );
   const [endDate, setEndDate] = useState<Dayjs>(dayjs());
   const [selectedProducts, setSelectedProducts] = useState<number[]>([]);
+
+  const {
+    palette: { mode },
+  } = useTheme();
 
   const { data, isFetching } = useQuery({
     queryKey: ["analytics", selectedProducts, startDate, endDate],
@@ -115,7 +120,7 @@ const ProductsAnalytics = () => {
               // Collect all unique dates and products
               Object.entries(data).forEach(([name, values]) => {
                 allProducts.add(name);
-                values.forEach(([date, value]) => {
+                values.forEach(([date, _]) => {
                   allDates.add(date);
                 });
               });
@@ -242,7 +247,7 @@ const ProductsAnalytics = () => {
             <EChartsReact
               option={options}
               style={{ height: 500 }}
-              theme="dark"
+              theme={mode}
               notMerge={true}
             />
           </Grid>

--- a/Store/src/pages/Analytics/Components/SalesAnalytics.tsx
+++ b/Store/src/pages/Analytics/Components/SalesAnalytics.tsx
@@ -12,6 +12,7 @@ import {
   MenuItem,
   Select,
   Typography,
+  useTheme,
 } from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -44,6 +45,10 @@ const SalesAnalytics = () => {
   );
   const [endDate, setEndDate] = useState<Dayjs>(dayjs());
   const [types, setTypes] = useState<string[]>(["sell", "return"]);
+
+  const {
+    palette: { mode },
+  } = useTheme();
 
   const { data, isFetching } = useQuery({
     queryKey: ["analytics", "sales", startDate, endDate, types],
@@ -189,7 +194,7 @@ const SalesAnalytics = () => {
             <EChartsReact
               option={options}
               style={{ height: 500 }}
-              theme="dark"
+              theme={mode}
               notMerge={true}
             />
           </Grid>

--- a/Store/src/pages/Analytics/Components/ShiftsAnalytics.tsx
+++ b/Store/src/pages/Analytics/Components/ShiftsAnalytics.tsx
@@ -12,6 +12,7 @@ import {
   MenuItem,
   Select,
   Typography,
+  useTheme,
 } from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -50,6 +51,10 @@ const ShiftsAnalytics = () => {
     "sell",
     "return",
   ]);
+
+  const {
+    palette: { mode },
+  } = useTheme();
 
   const { data, isFetching } = useQuery({
     queryKey: ["analytics", startDate, endDate, requiredTypes],
@@ -242,7 +247,7 @@ const ShiftsAnalytics = () => {
             <EChartsReact
               option={options}
               style={{ height: 500 }}
-              theme="dark"
+              theme={mode}
               notMerge={true}
             />
           </Grid>

--- a/Store/src/pages/Analytics/Components/TopProductsAnalytics.tsx
+++ b/Store/src/pages/Analytics/Components/TopProductsAnalytics.tsx
@@ -2,7 +2,14 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import dayjs, { Dayjs } from "dayjs";
 import { useCallback, useMemo, useState } from "react";
-import { Button, ButtonGroup, Card, Grid, Typography } from "@mui/material";
+import {
+  Button,
+  ButtonGroup,
+  Card,
+  Grid,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import EChartsReact from "echarts-for-react";
@@ -30,6 +37,10 @@ const TopProductsAnalytics = () => {
     dayjs().subtract(1, "month")
   );
   const [endDate, setEndDate] = useState<Dayjs>(dayjs());
+
+  const {
+    palette: { mode },
+  } = useTheme();
 
   const { data, isFetching } = useQuery({
     queryKey: ["analytics", "top-products", startDate, endDate],
@@ -80,7 +91,7 @@ const TopProductsAnalytics = () => {
               // Collect all unique dates and products
               Object.entries(data).forEach(([name, values]) => {
                 allProducts.add(name);
-                values.forEach(([date, value]) => {
+                values.forEach(([date, _]) => {
                   allDates.add(date);
                 });
               });
@@ -190,7 +201,7 @@ const TopProductsAnalytics = () => {
             <EChartsReact
               option={options}
               style={{ height: 500 }}
-              theme="dark"
+              theme={mode}
               notMerge={true}
             />
           </Grid>

--- a/Store/src/pages/Employee/Employee.tsx
+++ b/Store/src/pages/Employee/Employee.tsx
@@ -113,7 +113,6 @@ export default function Employee() {
   return (
     <ViewContainer>
       <Button
-        color="info"
         id="addEmployeeBtn"
         variant="contained"
         onClick={() => handleSelectEmployee(null, true)}

--- a/Store/src/pages/Setting/Components/Themes.tsx
+++ b/Store/src/pages/Setting/Components/Themes.tsx
@@ -1,92 +1,51 @@
-import React, { useState, useEffect } from 'react';
-import { Grid, Card, Typography, Button } from '@mui/material';
-
-const themes = [
-  {
-    name: 'Light Blue',
-    mode: 'light',
-    primary: '#1976d2',
-    secondary: '#ff4081',
-    background: '#e3f2fd',
-  },
-  {
-    name: 'Light Green',
-    mode: 'light',
-    primary: '#388e3c',
-    secondary: '#ffeb3b',
-    background: '#e8f5e9',
-  },
-  {
-    name: 'Light Orange',
-    mode: 'light',
-    primary: '#f57c00',
-    secondary: '#ffca28',
-    background: '#fff3e0',
-  },
-  {
-    name: 'Dark Blue',
-    mode: 'dark',
-    primary: '#0d47a1',
-    secondary: '#ff4081',
-    background: '#1a237e',
-  },
-  {
-    name: 'Dark Green',
-    mode: 'dark',
-    primary: '#1b5e20',
-    secondary: '#ffeb3b',
-    background: '#2e7d32',
-  },
-  {
-    name: 'Dark Orange',
-    mode: 'dark',
-    primary: '#e65100',
-    secondary: '#ffca28',
-    background: '#bf360c',
-  },
-];
+import { useState, useEffect } from "react";
+import { Grid, Card, Typography, Button } from "@mui/material";
+import { themes } from "../../../themes";
 
 const Themes = () => {
   const [selectedTheme, setSelectedTheme] = useState(() => {
-    const savedTheme = localStorage.getItem('selectedTheme');
-    return savedTheme ? JSON.parse(savedTheme) : themes[0];
+    const savedTheme = localStorage.getItem("themeName");
+    return savedTheme ? savedTheme : themes[0].name;
   });
 
   useEffect(() => {
-    localStorage.setItem('selectedTheme', JSON.stringify(selectedTheme));
+    localStorage.setItem("themeName", selectedTheme);
   }, [selectedTheme]);
 
   return (
     <Grid container spacing={2}>
       {themes.map((theme) => (
-        <Grid item xs={12} sm={6} md={4} key={theme.name}>
+        <Grid item xs={6} key={theme.name}>
           <Card
             style={{
               backgroundColor: theme.background,
-              color: theme.mode === 'dark' ? '#fff' : '#000',
-              padding: '16px',
-              textAlign: 'center',
+              color: theme.mode === "dark" ? "#fff" : "#000",
+              padding: "16px",
+              textAlign: "center",
             }}
           >
             <Typography variant="h6">{theme.name}</Typography>
             <div
               style={{
                 backgroundColor: theme.primary,
-                height: '50px',
-                margin: '8px 0',
+                height: "50px",
+                margin: "8px 0",
               }}
             />
             <div
               style={{
                 backgroundColor: theme.secondary,
-                height: '50px',
-                margin: '8px 0',
+                height: "50px",
+                margin: "8px 0",
               }}
             />
             <Button
               variant="contained"
               color="primary"
-              onClick={() => setSelectedTheme(theme)}
+              onClick={() => {
+                setSelectedTheme(theme.name);
+                window.location.reload();
+              }}
             >
               Select
             </Button>

--- a/Store/src/pages/Setting/Components/Themes.tsx
+++ b/Store/src/pages/Setting/Components/Themes.tsx
@@ -1,1 +1,100 @@
-// to be implemented
+import React, { useState, useEffect } from 'react';
+import { Grid, Card, Typography, Button } from '@mui/material';
+
+const themes = [
+  {
+    name: 'Light Blue',
+    mode: 'light',
+    primary: '#1976d2',
+    secondary: '#ff4081',
+    background: '#e3f2fd',
+  },
+  {
+    name: 'Light Green',
+    mode: 'light',
+    primary: '#388e3c',
+    secondary: '#ffeb3b',
+    background: '#e8f5e9',
+  },
+  {
+    name: 'Light Orange',
+    mode: 'light',
+    primary: '#f57c00',
+    secondary: '#ffca28',
+    background: '#fff3e0',
+  },
+  {
+    name: 'Dark Blue',
+    mode: 'dark',
+    primary: '#0d47a1',
+    secondary: '#ff4081',
+    background: '#1a237e',
+  },
+  {
+    name: 'Dark Green',
+    mode: 'dark',
+    primary: '#1b5e20',
+    secondary: '#ffeb3b',
+    background: '#2e7d32',
+  },
+  {
+    name: 'Dark Orange',
+    mode: 'dark',
+    primary: '#e65100',
+    secondary: '#ffca28',
+    background: '#bf360c',
+  },
+];
+
+const Themes = () => {
+  const [selectedTheme, setSelectedTheme] = useState(() => {
+    const savedTheme = localStorage.getItem('selectedTheme');
+    return savedTheme ? JSON.parse(savedTheme) : themes[0];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('selectedTheme', JSON.stringify(selectedTheme));
+  }, [selectedTheme]);
+
+  return (
+    <Grid container spacing={2}>
+      {themes.map((theme) => (
+        <Grid item xs={12} sm={6} md={4} key={theme.name}>
+          <Card
+            style={{
+              backgroundColor: theme.background,
+              color: theme.mode === 'dark' ? '#fff' : '#000',
+              padding: '16px',
+              textAlign: 'center',
+            }}
+          >
+            <Typography variant="h6">{theme.name}</Typography>
+            <div
+              style={{
+                backgroundColor: theme.primary,
+                height: '50px',
+                margin: '8px 0',
+              }}
+            />
+            <div
+              style={{
+                backgroundColor: theme.secondary,
+                height: '50px',
+                margin: '8px 0',
+              }}
+            />
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={() => setSelectedTheme(theme)}
+            >
+              Select
+            </Button>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};
+
+export default Themes;

--- a/Store/src/pages/Setting/Setting.tsx
+++ b/Store/src/pages/Setting/Setting.tsx
@@ -6,6 +6,7 @@ import Scopes from "./Components/Scopes";
 import Parties from "./Components/Parties";
 import autoAnimate from "@formkit/auto-animate";
 import Users from "./Components/Users";
+import Themes from "./Components/Themes";
 
 const Settings = () => {
   const [tab, setTab] = useState("1");
@@ -24,6 +25,7 @@ const Settings = () => {
           <Tab label="المستخدمين" value="2" />
           <Tab label="الصلاحيات" value="3" />
           <Tab label="العملاء و الموردين" value="4" />
+          <Tab label="الثيمات" value="5" />
         </TabList>
         <Divider />
         <TabPanel value="1">
@@ -37,6 +39,9 @@ const Settings = () => {
         </TabPanel>
         <TabPanel value="4">
           <Parties />
+        </TabPanel>
+        <TabPanel value="5">
+          <Themes />
         </TabPanel>
       </TabContext>
     </Card>

--- a/Store/src/themes.tsx
+++ b/Store/src/themes.tsx
@@ -1,0 +1,272 @@
+export interface Theme {
+  name: string;
+  mode: "light" | "dark";
+  primary: string;
+  secondary: string;
+  background: string;
+  paper: string;
+  divider: string;
+  backgroundImage: string;
+  text: {
+    primary: string;
+    secondary: string;
+    disabled: string;
+  };
+  action: {
+    active: string;
+    hover: string;
+    selected: string;
+    disabled: string;
+  };
+  surface: {
+    main: string;
+    border: string;
+  };
+  error: string;
+  warning: string;
+  info: string;
+  success: string;
+}
+
+export const themes: Theme[] = [
+  {
+    name: "Light Blue",
+    mode: "light",
+    primary: "#1976d2",
+    secondary: "#7c4dff",
+    background: "#f8faff",
+    paper: "#ffffff",
+    divider: "rgba(0, 0, 0, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #f8faff 0%, #e3f2fd 50%, #bbdefb 100%)",
+    text: {
+      primary: "rgba(0, 0, 0, 0.87)",
+      secondary: "rgba(0, 0, 0, 0.6)",
+      disabled: "rgba(0, 0, 0, 0.38)",
+    },
+    action: {
+      active: "rgba(0, 0, 0, 0.54)",
+      hover: "rgba(25, 118, 210, 0.04)",
+      selected: "rgba(25, 118, 210, 0.08)",
+      disabled: "rgba(0, 0, 0, 0.26)",
+    },
+    surface: {
+      main: "#ffffff",
+      border: "rgba(0, 0, 0, 0.12)",
+    },
+    error: "#d32f2f",
+    warning: "#ed6c02",
+    info: "#0288d1",
+    success: "#2e7d32",
+  },
+  {
+    name: "Dark Blue",
+    mode: "dark",
+    primary: "#90caf9",
+    secondary: "#ce93d8",
+    background: "#0a1929",
+    paper: "#0d1b2a",
+    divider: "rgba(255, 255, 255, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #0a1929 0%, #0d1b2a 50%, #132f4c 100%)",
+    text: {
+      primary: "#ffffff",
+      secondary: "rgba(255, 255, 255, 0.7)",
+      disabled: "rgba(255, 255, 255, 0.5)",
+    },
+    action: {
+      active: "#ffffff",
+      hover: "rgba(144, 202, 249, 0.08)",
+      selected: "rgba(144, 202, 249, 0.16)",
+      disabled: "rgba(255, 255, 255, 0.3)",
+    },
+    surface: {
+      main: "#0d1b2a",
+      border: "rgba(255, 255, 255, 0.12)",
+    },
+    error: "#f44336",
+    warning: "#ffa726",
+    info: "#29b6f6",
+    success: "#66bb6a",
+  },
+  {
+    name: "Light Orange",
+    mode: "light",
+    primary: "#f57c00",
+    secondary: "#ff6090",
+    background: "#fffaf5",
+    paper: "#ffffff",
+    divider: "rgba(0, 0, 0, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #fffaf5 0%, #fff7e6 50%, #ffe0b2 100%)",
+    text: {
+      primary: "rgba(0, 0, 0, 0.87)",
+      secondary: "rgba(0, 0, 0, 0.6)",
+      disabled: "rgba(0, 0, 0, 0.38)",
+    },
+    action: {
+      active: "rgba(0, 0, 0, 0.54)",
+      hover: "rgba(245, 124, 0, 0.04)",
+      selected: "rgba(245, 124, 0, 0.08)",
+      disabled: "rgba(0, 0, 0, 0.26)",
+    },
+    surface: {
+      main: "#ffffff",
+      border: "rgba(0, 0, 0, 0.12)",
+    },
+    error: "#ffa0a0",
+    warning: "#f57c00",
+    info: "#0288d1",
+    success: "#2e7d32",
+  },
+  {
+    name: "Dark Orange",
+    mode: "dark",
+    primary: "#fb8c00",
+    secondary: "#ff9cad",
+    background: "#1a0f00",
+    paper: "#261a0f",
+    divider: "rgba(255, 255, 255, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #1a0f00 0%, #261a0f 50%, #332211 100%)",
+    text: {
+      primary: "#ffffff",
+      secondary: "rgba(255, 255, 255, 0.7)",
+      disabled: "rgba(255, 255, 255, 0.5)",
+    },
+    action: {
+      active: "#ffffff",
+      hover: "rgba(255, 167, 38, 0.08)",
+      selected: "rgba(255, 167, 38, 0.16)",
+      disabled: "rgba(255, 255, 255, 0.3)",
+    },
+    surface: {
+      main: "#261a0f",
+      border: "rgba(255, 255, 255, 0.12)",
+    },
+    error: "#411a0f",
+    warning: "#ffa726",
+    info: "#29b6f6",
+    success: "#66bb6a",
+  },
+  {
+    name: "Light Green",
+    mode: "light",
+    primary: "#2e7d32",
+    secondary: "#00796b",
+    background: "#f6fbf6",
+    paper: "#ffffff",
+    divider: "rgba(0, 0, 0, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #f6fbf6 0%, #e8f5e9 50%, #c8e6c9 100%)",
+    text: {
+      primary: "rgba(0, 0, 0, 0.87)",
+      secondary: "rgba(0, 0, 0, 0.6)",
+      disabled: "rgba(0, 0, 0, 0.38)",
+    },
+    action: {
+      active: "rgba(0, 0, 0, 0.54)",
+      hover: "rgba(46, 125, 50, 0.04)",
+      selected: "rgba(46, 125, 50, 0.08)",
+      disabled: "rgba(0, 0, 0, 0.26)",
+    },
+    surface: {
+      main: "#ffffff",
+      border: "rgba(0, 0, 0, 0.12)",
+    },
+    error: "#d32f2f",
+    warning: "#ed6c02",
+    info: "#0288d1",
+    success: "#2e7d32",
+  },
+  {
+    name: "Dark Green",
+    mode: "dark",
+    primary: "#81c784",
+    secondary: "#a5d6a7",
+    background: "#071912",
+    paper: "#0f2918",
+    divider: "rgba(255, 255, 255, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #071912 0%, #0f2918 50%, #1a3828 100%)",
+    text: {
+      primary: "#ffffff",
+      secondary: "rgba(255, 255, 255, 0.7)",
+      disabled: "rgba(255, 255, 255, 0.5)",
+    },
+    action: {
+      active: "#ffffff",
+      hover: "rgba(129, 199, 132, 0.08)",
+      selected: "rgba(129, 199, 132, 0.16)",
+      disabled: "rgba(255, 255, 255, 0.3)",
+    },
+    surface: {
+      main: "#0f2918",
+      border: "rgba(255, 255, 255, 0.12)",
+    },
+    error: "#b44336",
+    warning: "#ffa726",
+    info: "#29b6f6",
+    success: "#66bb6a",
+  },
+  {
+    name: "Light Red",
+    mode: "light",
+    primary: "#e57373",
+    secondary: "#f06292",
+    background: "#fff8f8",
+    paper: "#ffffff",
+    divider: "rgba(0, 0, 0, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #fff8f8 0%, #ffefef 50%, #ffe1e1 100%)",
+    text: {
+      primary: "rgba(0, 0, 0, 0.87)",
+      secondary: "rgba(0, 0, 0, 0.6)",
+      disabled: "rgba(0, 0, 0, 0.38)",
+    },
+    action: {
+      active: "rgba(0, 0, 0, 0.54)",
+      hover: "rgba(229, 115, 115, 0.04)",
+      selected: "rgba(229, 115, 115, 0.08)",
+      disabled: "rgba(0, 0, 0, 0.26)",
+    },
+    surface: {
+      main: "#ffffff",
+      border: "rgba(0, 0, 0, 0.12)",
+    },
+    error: "#f54343",
+    warning: "#ed6c02",
+    info: "#0288d1",
+    success: "#2e7d32",
+  },
+  {
+    name: "Dark Red",
+    mode: "dark",
+    primary: "#ff8a80",
+    secondary: "#ff80ab",
+    background: "#1f1414",
+    paper: "#2a1c1c",
+    divider: "rgba(255, 255, 255, 0.12)",
+    backgroundImage:
+      "linear-gradient(135deg, #1f1414 0%, #2a1c1c 50%, #352424 100%)",
+    text: {
+      primary: "#ffffff",
+      secondary: "rgba(255, 255, 255, 0.7)",
+      disabled: "rgba(255, 255, 255, 0.5)",
+    },
+    action: {
+      active: "#ffffff",
+      hover: "rgba(255, 138, 128, 0.08)",
+      selected: "rgba(255, 138, 128, 0.16)",
+      disabled: "rgba(255, 255, 255, 0.3)",
+    },
+    surface: {
+      main: "#2a1c1c",
+      border: "rgba(255, 255, 255, 0.12)",
+    },
+    error: "#6f5050",
+    warning: "#ffa726",
+    info: "#29b6f6",
+    success: "#66bb6a",
+  },
+];


### PR DESCRIPTION
Add a new themes section in the settings page and implement theme selection and preview functionality.

* **Store/src/pages/Setting/Setting.tsx**
  - Import the Themes component.
  - Add a new tab for themes in the TabList component.
  - Add a new TabPanel for themes in the TabContext component.

* **Store/src/pages/Setting/Components/Themes.tsx**
  - Implement the Themes component to display 6 themes, 3 dark and 3 light.
  - Add functionality to select and preview themes.
  - Save the selected theme in localStorage.

* **Store/src/App.tsx**
  - Update the App component to handle 6 themes, 3 dark and 3 light.
  - Load the selected theme from localStorage.
  - Update theme settings including primary, secondary, and background colors.

